### PR TITLE
Add tests for invalid mask bits

### DIFF
--- a/main.py
+++ b/main.py
@@ -777,12 +777,32 @@ def case08_deserialization_G1():
         'output': False,
     }
 
-    pk = 'e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+    pk = 'e491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a'
     pk_for_wire = G1Compressed(os2ip(bytes.fromhex(pk)))
     expect_exception(decompress_G1, pk_for_wire)
-    yield 'deserialization_fails_with_b_flag_and_a_flag_true', {
+    yield 'deserialization_fails_with_mask_bits_111', {
         'input': {
-            'pubkey': pk
+            'pubkey': pk,
+        },
+        'output': False,
+    }
+
+    pk = '6491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a'
+    pk_for_wire = G1Compressed(os2ip(bytes.fromhex(pk)))
+    expect_exception(decompress_G1, pk_for_wire)
+    yield 'deserialization_fails_with_mask_bits_011', {
+        'input': {
+            'pubkey': pk,
+        },
+        'output': False,
+    }
+
+    pk = '2491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a'
+    pk_for_wire = G1Compressed(os2ip(bytes.fromhex(pk)))
+    expect_exception(decompress_G1, pk_for_wire)
+    yield 'deserialization_fails_with_mask_bits_001', {
+        'input': {
+            'pubkey': pk,
         },
         'output': False,
     }
@@ -950,11 +970,33 @@ def case09_deserialization_G2():
         'output': False,
     }
 
-    sig = 'e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+    sig = 'f2cc74bc9f089ed9764bbceac5edba416bef5e73701288977b9cac1ccb6964269d4ebf78b4e8aa7792ba09d3e49c8e6a1351bdf582971f796bbaf6320e81251c9d28f674d720cca07ed14596b96697cf18238e0e03ebd7fc1353d885a39407e0'
     sig_for_wire = bytes.fromhex(sig)
     secretKey = G2Compressed((os2ip(sig_for_wire[:48]), os2ip(sig_for_wire[48:])))
     expect_exception(decompress_G2, secretKey)
-    yield 'deserialization_fails_with_b_flag_and_a_flag_true', {
+    yield 'deserialization_fails_with_mask_bits_111', {
+        'input': {
+            'signature': sig
+        },
+        'output': False,
+    }
+
+    sig = '72cc74bc9f089ed9764bbceac5edba416bef5e73701288977b9cac1ccb6964269d4ebf78b4e8aa7792ba09d3e49c8e6a1351bdf582971f796bbaf6320e81251c9d28f674d720cca07ed14596b96697cf18238e0e03ebd7fc1353d885a39407e0'
+    sig_for_wire = bytes.fromhex(sig)
+    secretKey = G2Compressed((os2ip(sig_for_wire[:48]), os2ip(sig_for_wire[48:])))
+    expect_exception(decompress_G2, secretKey)
+    yield 'deserialization_fails_with_mask_bits_011', {
+        'input': {
+            'signature': sig
+        },
+        'output': False,
+    }
+
+    sig = '32cc74bc9f089ed9764bbceac5edba416bef5e73701288977b9cac1ccb6964269d4ebf78b4e8aa7792ba09d3e49c8e6a1351bdf582971f796bbaf6320e81251c9d28f674d720cca07ed14596b96697cf18238e0e03ebd7fc1353d885a39407e0'
+    sig_for_wire = bytes.fromhex(sig)
+    secretKey = G2Compressed((os2ip(sig_for_wire[:48]), os2ip(sig_for_wire[48:])))
+    expect_exception(decompress_G2, secretKey)
+    yield 'deserialization_fails_with_mask_bits_001', {
         'input': {
             'signature': sig
         },

--- a/main.py
+++ b/main.py
@@ -777,6 +777,16 @@ def case08_deserialization_G1():
         'output': False,
     }
 
+    pk = 'e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+    pk_for_wire = G1Compressed(os2ip(bytes.fromhex(pk)))
+    expect_exception(decompress_G1, pk_for_wire)
+    yield 'deserialization_fails_with_b_flag_and_a_flag_true', {
+        'input': {
+            'pubkey': pk
+        },
+        'output': False,
+    }
+
     pk = 'e491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a'
     pk_for_wire = G1Compressed(os2ip(bytes.fromhex(pk)))
     expect_exception(decompress_G1, pk_for_wire)
@@ -964,6 +974,17 @@ def case09_deserialization_G2():
     secretKey = G2Compressed((os2ip(sig_for_wire[:48]), os2ip(sig_for_wire[48:])))
     expect_exception(decompress_G2, secretKey)
     yield 'deserialization_fails_with_b_flag_and_x_nonzero', {
+        'input': {
+            'signature': sig
+        },
+        'output': False,
+    }
+
+    sig = 'e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+    sig_for_wire = bytes.fromhex(sig)
+    secretKey = G2Compressed((os2ip(sig_for_wire[:48]), os2ip(sig_for_wire[48:])))
+    expect_exception(decompress_G2, secretKey)
+    yield 'deserialization_fails_with_b_flag_and_a_flag_true', {
         'input': {
             'signature': sig
         },


### PR DESCRIPTION
This PR adds test cases for the invalid mask bits (aka flags) at the beginning of each G1/G2 point. The `pk` and `sig` values in these new test cases were copied from the `deserialization_succeeds_correct_point` test case respectively, then their mask bits were overwritten. I believe the the `fails_with_mask_bits_111` is the same as `fails_with_b_flag_and_a_flag`, so I replaced the latter to be consistent with the other new tests.