### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 py_ecc==6.0.0
-milagro-bls-binding==1.7.0
-ruamel.yaml==0.17.10
+milagro-bls-binding==1.9.0
+ruamel.yaml==0.17.22


### PR DESCRIPTION
On my system (macOS, arm64), `milagro-bls-binding==1.7.0` is not available. This is a good excuse to update these.

```
$ pip install --upgrade -r requirements.txt
Collecting py_ecc==6.0.0 (from -r requirements.txt (line 1))
  Using cached py_ecc-6.0.0-py3-none-any.whl (43 kB)
ERROR: Could not find a version that satisfies the requirement milagro-bls-binding==1.7.0 (from versions: 0.1.4, 0.4.0, 1.0.0, 1.0.1, 1.8.0, 1.8.1, 1.9.0)
ERROR: No matching distribution found for milagro-bls-binding==1.7.0
```