### PR TITLE
Fix nits in the EIP-2537 test formats

### DIFF
--- a/formats/add_G1_bls.md
+++ b/formats/add_G1_bls.md
@@ -11,13 +11,12 @@ The test data is declared in a 'json' file:
     {
         "Input": 256 bytes as an input that is interpreted as byte concatenation of two G1 points (128 bytes each),
         "Name": the name of the test,
-        "Expected": single G1 point 128 bytes,
+        "Expected": single G1 point (128 bytes),
         "Gas": the cost of the gas,
         "NoBenchmark": True/False
     },
-    ....
+    ...
 ]
 ```
 
 All byte(s) fields are encoded as strings, hexadecimal encoding
-

--- a/formats/add_G2_bls.md
+++ b/formats/add_G2_bls.md
@@ -9,13 +9,13 @@ The test data is declared in a 'json' file:
 ```
 [
     {
-        "Input": 512 bytes as an input that is interpreted as byte concatenation of two G2 points (256 bytes each). 
+        "Input": 512 bytes as an input that is interpreted as byte concatenation of two G2 points (256 bytes each),
         "Name": the name of the test,
-        "Expected": single G2 point (256 bytes).
+        "Expected": single G2 point (256 bytes),
         "Gas": the cost of the gas,
         "NoBenchmark": True/False
     },
-    ....
+    ...
 ]
 ```
 

--- a/formats/map_fp2_to_G2_bls.md
+++ b/formats/map_fp2_to_G2_bls.md
@@ -11,7 +11,7 @@ The test data is declared in a 'json' file:
     {
         "Input": 128 bytes as an input that is interpreted as a an element of the quadratic extension field,
         "Name": the name of the test,
-        "Expected": single G2 point 256 bytes,
+        "Expected": single G2 point (256 bytes),
         "Gas": the cost of the gas,
         "NoBenchmark": True/False
     },
@@ -20,4 +20,3 @@ The test data is declared in a 'json' file:
 ```
 
 All byte(s) fields are encoded as strings, hexadecimal encoding
-

--- a/formats/map_fp_to_G1_bls.md
+++ b/formats/map_fp_to_G1_bls.md
@@ -11,13 +11,12 @@ The test data is declared in a 'json' file:
     {
         "Input": 64 bytes as an input that is interpreted as an element of the base field,
         "Name": the name of the test,
-        "Expected": single G1 point 128 bytes,
+        "Expected": single G1 point (128 bytes),
         "Gas": the cost of the gas,
         "NoBenchmark": True/False
     },
-    ....
+    ...
 ]
 ```
 
 All byte(s) fields are encoded as strings, hexadecimal encoding
-

--- a/formats/mul_G1_bls.md
+++ b/formats/mul_G1_bls.md
@@ -12,13 +12,12 @@ The test data is declared in a 'json' file:
         "Input": 160 bytes as an input that is interpreted as byte concatenation of
          encoding of G1 point (128 bytes) and encoding of a scalar value (32 bytes),
         "Name": the name of the test,
-        "Expected": single G1 point 128 bytes,
+        "Expected": single G1 point (128 bytes),
         "Gas": the cost of the gas,
         "NoBenchmark": True/False
     },
-    ....
+    ...
 ]
 ```
 
 All byte(s) fields are encoded as strings, hexadecimal encoding
-

--- a/formats/mul_G2_bls.md
+++ b/formats/mul_G2_bls.md
@@ -10,15 +10,14 @@ The test data is declared in a 'json' file:
 [
     {
         "Input": call expects 288 bytes as an input that is interpreted as byte concatenation
-         of encoding of G2 point (256 bytes) and encoding of a scalar value (32 bytes).,
+         of encoding of G2 point (256 bytes) and encoding of a scalar value (32 bytes),
         "Name": the name of the test,
-        "Expected": single G2 point 256 bytes,
+        "Expected": single G2 point (256 bytes),
         "Gas": the cost of the gas,
         "NoBenchmark": True/False
     },
-    ....
+    ...
 ]
 ```
 
 All byte(s) fields are encoded as strings, hexadecimal encoding
-

--- a/formats/multiexp_G1_bls.md
+++ b/formats/multiexp_G1_bls.md
@@ -13,13 +13,12 @@ The test data is declared in a 'json' file:
         of them being a byte concatenation of encoding of G1 point (128 bytes) and encoding of a
         scalar value (32 bytes),
         "Name": the name of the test,
-        "Expected": single G1 point 128 bytes,
+        "Expected": single G1 point (128 bytes),
         "Gas": the cost of the gas,
         "NoBenchmark": True/False
     },
-    ....
+    ...
 ]
 ```
 
 All byte(s) fields are encoded as strings, hexadecimal encoding
-

--- a/formats/multiexp_G2_bls.md
+++ b/formats/multiexp_G2_bls.md
@@ -1,4 +1,4 @@
-# Test format:  'BLS12_G2MULTIEXP'
+# Test format: 'BLS12_G2MULTIEXP'
 
 multiexponentiation in G2
 
@@ -13,11 +13,11 @@ The test data is declared in a 'json' file:
         of them being a byte concatenation of encoding of G2 point (256 bytes) and encoding of a
         scalar value (32 bytes),
         "Name": the name of the test,
-        "Expected": single G2 point 256 bytes,
+        "Expected": single G2 point (256 bytes),
         "Gas": the cost of the gas,
         "NoBenchmark": True/False
     },
-    ....
+    ...
 ]
 ```
 


### PR DESCRIPTION
* Add parentheses around byte sizes, for consistency.
* Replace periods with commas in some places.
* Replace quad .... with triple ... which is more common.
* Remove excess new lines at the bottom.