### PR TITLE
Add new point at infinity pairing check tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ lint:
 	# Ignored:
 	#   - E122 continuation line missing indentation or outdented
 	#   - E501 line too long
-	flake8 . --count --ignore=E122,E501 --max-complexity=10 --max-line-length=127 --statistics --exclude=venv
+	#   - W503 line break before binary operator
+	flake8 . --count --ignore=E122,E501,W503 --max-complexity=10 --max-line-length=127 --statistics --exclude=venv
 
 generate_yaml:
 	mkdir -p out/yaml

--- a/main.py
+++ b/main.py
@@ -1567,7 +1567,7 @@ def case18_fail_pairing_check():
             + int_to_hex(int(neg(G2)[1].coeffs[0]), 64)
             + int_to_hex(int(neg(G2)[1].coeffs[1]), 64),
         "ExpectedError": "invalid fp.Element encoding",
-        "Name": "bls_pairing_e(G1,-G2_invalid_field_element)=e(-G1,G2)",
+        "Name": "bls_pairing_e(G1,G2_invalid_field_element)=e(-G1,G2)",
         },
         {
         "Input": ""
@@ -1695,7 +1695,7 @@ def case18_fail_pairing_check():
             int(G1[0]), 64) + (int_to_hex(int(G1[1]), 64)) + int_to_hex(int(neg(G2)[0].coeffs[0]), 64) + int_to_hex(
             int(neg(G2)[0].coeffs[1]), 64) + int_to_hex(int(neg(G2)[1].coeffs[0]), 64) + int_to_hex(int(neg(G2)[1].coeffs[1]), 64),
         "ExpectedError": "g2 point is not on correct subgroup",
-        "Name": "bls_pairing_e(G1,-G2_not_in_correct_subgroup)=e(-G1,G2)"
+        "Name": "bls_pairing_e(G1,G2_not_in_correct_subgroup)=e(-G1,G2)"
         }
     ]
 

--- a/main.py
+++ b/main.py
@@ -1027,6 +1027,32 @@ def case09_pairing_check():
 
     yield 'pairing_check_bls', [
         {
+        "Input": ""
+            # G1 point (point at infinity)
+            + int_to_hex(0, 128)
+            # G2 point
+            + int_to_hex(int(G2[0].coeffs[0]), 64)
+            + int_to_hex(int(G2[0].coeffs[1]), 64)
+            + int_to_hex(int(G2[1].coeffs[0]), 64)
+            + int_to_hex(int(G2[1].coeffs[1]), 64),
+        "Name": "bls_pairing_e(0,G2)",
+        "Expected": int_to_hex(1, 32),
+        "Gas": 1 * BLS12_PAIRING_VARIABLE + BLS12_PAIRING_CONSTANT,
+        "NoBenchmark": False
+        },
+        {
+        "Input": ""
+            # G1 point
+            + int_to_hex(int(G1[0]), 64)
+            + int_to_hex(int(G1[1]), 64)
+            # G2 point (point at infinity)
+            + int_to_hex(0, 256),
+        "Name": "bls_pairing_e(G1,0)",
+        "Expected": int_to_hex(1, 32),
+        "Gas": 1 * BLS12_PAIRING_VARIABLE + BLS12_PAIRING_CONSTANT,
+        "NoBenchmark": False
+        },
+        {
         "Input": int_to_hex(int(G1[0]), 64) + (int_to_hex(int(G1[1]), 64)) + int_to_hex(0, 256) + int_to_hex(0, 128) + int_to_hex(int(G2[0].coeffs[0]), 64) + int_to_hex(
             int(G2[0].coeffs[1]), 64) + int_to_hex(int(G2[1].coeffs[0]), 64) + int_to_hex(int(G2[1].coeffs[1]), 64),
         "Name": "bls_pairing_e(G1,0)=e(0,G2)",

--- a/main.py
+++ b/main.py
@@ -1550,6 +1550,27 @@ def case18_fail_pairing_check():
         },
         {
         "Input": ""
+            # G1 point 1
+            + int_to_hex(int(G1[0]), 64)
+            + int_to_hex(int(G1[1]), 64)
+            # G1 point 1
+            + int_to_hex(int(G2[0].coeffs[0]) + q, 64) # Plus Q
+            + int_to_hex(int(G2[0].coeffs[1]), 64)
+            + int_to_hex(int(G2[1].coeffs[0]), 64)
+            + int_to_hex(int(G2[1].coeffs[1]), 64)
+            # G1 point 2
+            + int_to_hex(int(G1[0]), 64)
+            + int_to_hex(int(G1[1]), 64)
+            # G1 point 2
+            + int_to_hex(int(neg(G2)[0].coeffs[0]), 64)
+            + int_to_hex(int(neg(G2)[0].coeffs[1]), 64)
+            + int_to_hex(int(neg(G2)[1].coeffs[0]), 64)
+            + int_to_hex(int(neg(G2)[1].coeffs[1]), 64),
+        "ExpectedError": "invalid fp.Element encoding",
+        "Name": "bls_pairing_e(G1,-G2_invalid_field_element)=e(-G1,G2)",
+        },
+        {
+        "Input": ""
             # G1 point (not on curve)
             + int_to_hex(int(P1[0]), 64) # Using P1 instead of G1
             + int_to_hex(int(G1[1]), 64)

--- a/main.py
+++ b/main.py
@@ -1507,10 +1507,10 @@ def case18_fail_pairing_check():
             # G1 point (point at infinity)
             + int_to_hex(0, 128)
             # G2 point (invalid field element)
-            + int_to_hex(int(G2[0].coeffs[0]), 64)
+            + int_to_hex(int(G2[0].coeffs[0]) + q, 64) # Plus Q
             + int_to_hex(int(G2[0].coeffs[1]), 64)
             + int_to_hex(int(G2[1].coeffs[0]), 64)
-            + int_to_hex(int(G2[1].coeffs[1]) + q, 64), # Plus Q
+            + int_to_hex(int(G2[1].coeffs[1]), 64),
         "ExpectedError": "invalid fp.Element encoding",
         "Name": "bls_pairing_e(0,G2_invalid_field_element)",
         },
@@ -1610,7 +1610,7 @@ def case18_fail_pairing_check():
             int(G1[0]), 64) + (int_to_hex(int(G1[1]), 64)) + int_to_hex(int(neg(G2)[0].coeffs[0]), 64) + int_to_hex(
             int(neg(G2)[0].coeffs[1]), 64) + int_to_hex(int(neg(G2)[1].coeffs[0]), 64) + int_to_hex(int(neg(G2)[1].coeffs[1]), 64),
         "ExpectedError": "invalid point: not on curve",
-        "Name": "bls_pairing_e(G1,-G2_not_on_curve)=e(-G1,G2)"
+        "Name": "bls_pairing_e(G1,G2_not_on_curve)=e(-G1,G2)"
         },
         {
         "Input": ""

--- a/main.py
+++ b/main.py
@@ -1451,12 +1451,108 @@ def case18_fail_pairing_check():
         "Name": "bls_pairing_top_bytes"
         },
         {
+        "Input": ""
+            # G1 point (invalid field element)
+            + int_to_hex(int(G1[0]) + q, 64) # Plus Q
+            + int_to_hex(int(G1[1]), 64)
+            # G2 point (point at infinity)
+            + int_to_hex(0, 256),
+        "ExpectedError": "invalid fp.Element encoding",
+        "Name": "bls_pairing_e(G1_invalid_field_element,0)",
+        },
+        {
+        "Input": ""
+            # G1 point (point at infinity)
+            + int_to_hex(0, 128)
+            # G2 point (invalid field element)
+            + int_to_hex(int(G2[0].coeffs[0]), 64)
+            + int_to_hex(int(G2[0].coeffs[1]), 64)
+            + int_to_hex(int(G2[1].coeffs[0]), 64)
+            + int_to_hex(int(G2[1].coeffs[1]) + q, 64), # Plus Q
+        "ExpectedError": "invalid fp.Element encoding",
+        "Name": "bls_pairing_e(0,G2_invalid_field_element)",
+        },
+        {
+        "Input": ""
+            # G1 point
+            + int_to_hex(int(G1[0]) + q, 64) # Plus Q
+            + int_to_hex(int(G1[1]), 64)
+            # G2 point (invalid field element)
+            + int_to_hex(int(G2[0].coeffs[0]), 64)
+            + int_to_hex(int(G2[0].coeffs[1]), 64)
+            + int_to_hex(int(G2[1].coeffs[0]), 64)
+            + int_to_hex(int(G2[1].coeffs[1]), 64),
+        "ExpectedError": "invalid fp.Element encoding",
+        "Name": "bls_pairing_e(G1_invalid_field_element,G2)",
+        },
+        {
+        "Input": ""
+            # G1 point
+            + int_to_hex(int(G1[0]), 64)
+            + int_to_hex(int(G1[1]), 64)
+            # G2 point (invalid field element)
+            + int_to_hex(int(G2[0].coeffs[0]) + q, 64) # Plus Q
+            + int_to_hex(int(G2[0].coeffs[1]), 64)
+            + int_to_hex(int(G2[1].coeffs[0]), 64)
+            + int_to_hex(int(G2[1].coeffs[1]), 64),
+        "ExpectedError": "invalid fp.Element encoding",
+        "Name": "bls_pairing_e(G1,G2_invalid_field_element)",
+        },
+        {
         "Input": int_to_hex(int(G1[0]) + q, 64) + (int_to_hex(int(G1[1]), 64)) + int_to_hex(int(G2[0].coeffs[0]), 64) + int_to_hex(
             int(G2[0].coeffs[1]), 64) + int_to_hex(int(G2[1].coeffs[0]), 64) + int_to_hex(int(G2[1].coeffs[1]), 64) + int_to_hex(
             int(G1[0]), 64) + (int_to_hex(int(G1[1]), 64)) + int_to_hex(int(neg(G2)[0].coeffs[0]), 64) + int_to_hex(
             int(neg(G2)[0].coeffs[1]), 64) + int_to_hex(int(neg(G2)[1].coeffs[0]), 64) + int_to_hex(int(neg(G2)[1].coeffs[1]), 64),
         "ExpectedError": "invalid fp.Element encoding",
-        "Name": "bls_pairing_invalid_field_element"
+        "Name": "bls_pairing_e(G1_invalid_field_element,-G2)=e(-G1,G2)",
+        },
+        {
+        "Input": ""
+            # G1 point (not on curve)
+            + int_to_hex(int(P1[0]), 64) # Using P1 instead of G1
+            + int_to_hex(int(G1[1]), 64)
+            # G2 point (point at infinity)
+            + int_to_hex(0, 256),
+        "ExpectedError": "invalid point: not on curve",
+        "Name": "bls_pairing_e(G1_not_on_curve,0)",
+        },
+        {
+        "Input": ""
+            # G1 point (point at infinity)
+            + int_to_hex(0, 128)
+            # G2 point (not on curve)
+            + int_to_hex(int(P2[0].coeffs[0]), 64) # Using P2 instead of G2
+            + int_to_hex(int(G2[0].coeffs[1]), 64)
+            + int_to_hex(int(G2[1].coeffs[0]), 64)
+            + int_to_hex(int(G2[1].coeffs[1]), 64),
+        "ExpectedError": "invalid point: not on curve",
+        "Name": "bls_pairing_e(0,G2_not_on_curve)",
+        },
+        {
+        "Input": ""
+            # G1 point (not on curve)
+            + int_to_hex(int(P1[0]), 64) # Using P1 instead of G1
+            + int_to_hex(int(G1[1]), 64)
+            # G2 point
+            + int_to_hex(int(G2[0].coeffs[0]), 64)
+            + int_to_hex(int(G2[0].coeffs[1]), 64)
+            + int_to_hex(int(G2[1].coeffs[0]), 64)
+            + int_to_hex(int(G2[1].coeffs[1]), 64),
+        "ExpectedError": "invalid point: not on curve",
+        "Name": "bls_pairing_e(G1_not_on_curve,G2)",
+        },
+        {
+        "Input": ""
+            # G1 point
+            + int_to_hex(int(G1[0]), 64)
+            + int_to_hex(int(G1[1]), 64)
+            # G2 point (not on curve)
+            + int_to_hex(int(P2[0].coeffs[0]), 64) # Using P2 instead of G2
+            + int_to_hex(int(G2[0].coeffs[1]), 64)
+            + int_to_hex(int(G2[1].coeffs[0]), 64)
+            + int_to_hex(int(G2[1].coeffs[1]), 64),
+        "ExpectedError": "invalid point: not on curve",
+        "Name": "bls_pairing_e(G1,G2_not_on_curve)",
         },
         {
         "Input": int_to_hex(int(G1[0]), 64) + (int_to_hex(int(P1[1]), 64)) + int_to_hex(int(G2[0].coeffs[0]), 64) + int_to_hex(
@@ -1464,7 +1560,7 @@ def case18_fail_pairing_check():
             int(G1[0]), 64) + (int_to_hex(int(G1[1]), 64)) + int_to_hex(int(neg(G2)[0].coeffs[0]), 64) + int_to_hex(
             int(neg(G2)[0].coeffs[1]), 64) + int_to_hex(int(neg(G2)[1].coeffs[0]), 64) + int_to_hex(int(neg(G2)[1].coeffs[1]), 64),
         "ExpectedError": "invalid point: not on curve",
-        "Name": "bls_pairing_g1_not_on_curve"
+        "Name": "bls_pairing_e(G1_not_on_curve,-G2)=e(-G1,G2)"
         },
         {
         "Input": int_to_hex(int(G1[0]), 64) + (int_to_hex(int(G1[1]), 64)) + int_to_hex(int(G2[0].coeffs[0]), 64) + int_to_hex(
@@ -1472,7 +1568,55 @@ def case18_fail_pairing_check():
             int(G1[0]), 64) + (int_to_hex(int(G1[1]), 64)) + int_to_hex(int(neg(G2)[0].coeffs[0]), 64) + int_to_hex(
             int(neg(G2)[0].coeffs[1]), 64) + int_to_hex(int(neg(G2)[1].coeffs[0]), 64) + int_to_hex(int(neg(G2)[1].coeffs[1]), 64),
         "ExpectedError": "invalid point: not on curve",
-        "Name": "bls_pairing_g2_not_on_curve"
+        "Name": "bls_pairing_e(G1,-G2_not_on_curve)=e(-G1,G2)"
+        },
+        {
+        "Input": ""
+            # G1 point (not on curve)
+            + int_to_hex(int(G1_wrong_order[0]), 64)
+            + int_to_hex(int(G1_wrong_order[1]), 64)
+            # G2 point (point at infinity)
+            + int_to_hex(0, 256),
+        "ExpectedError": "g1 point is not on correct subgroup",
+        "Name": "bls_pairing_e(G1_not_in_correct_subgroup,0)",
+        },
+        {
+        "Input": ""
+            # G1 point (point at infinity)
+            + int_to_hex(0, 128)
+            # G2 point (not on curve)
+            + int_to_hex(int(G2_wrong_order[0].coeffs[0]), 64)
+            + int_to_hex(int(G2_wrong_order[0].coeffs[1]), 64)
+            + int_to_hex(int(G2_wrong_order[1].coeffs[0]), 64)
+            + int_to_hex(int(G2_wrong_order[1].coeffs[1]), 64),
+        "ExpectedError": "g2 point is not on correct subgroup",
+        "Name": "bls_pairing_e(0,G2_not_in_correct_subgroup)",
+        },
+        {
+        "Input": ""
+            # G1 point (not on curve)
+            + int_to_hex(int(G1_wrong_order[0]), 64)
+            + int_to_hex(int(G1_wrong_order[1]), 64)
+            # G2 point
+            + int_to_hex(int(G2[0].coeffs[0]), 64)
+            + int_to_hex(int(G2[0].coeffs[1]), 64)
+            + int_to_hex(int(G2[1].coeffs[0]), 64)
+            + int_to_hex(int(G2[1].coeffs[1]), 64),
+        "ExpectedError": "g1 point is not on correct subgroup",
+        "Name": "bls_pairing_e(G1_not_in_correct_subgroup,G2)",
+        },
+        {
+        "Input": ""
+            # G1 point
+            + int_to_hex(int(G1[0]), 64)
+            + int_to_hex(int(G1[1]), 64)
+            # G2 point (not on curve)
+            + int_to_hex(int(G2_wrong_order[0].coeffs[0]), 64)
+            + int_to_hex(int(G2_wrong_order[0].coeffs[1]), 64)
+            + int_to_hex(int(G2_wrong_order[1].coeffs[0]), 64)
+            + int_to_hex(int(G2_wrong_order[1].coeffs[1]), 64),
+        "ExpectedError": "g2 point is not on correct subgroup",
+        "Name": "bls_pairing_e(G1,G2_not_in_correct_subgroup)",
         },
         {
         "Input": int_to_hex(int(G1_wrong_order[0]), 64) + (int_to_hex(int(G1_wrong_order[1]), 64)) + int_to_hex(int(G2[0].coeffs[0]), 64) + int_to_hex(
@@ -1480,7 +1624,7 @@ def case18_fail_pairing_check():
             int(G1[0]), 64) + (int_to_hex(int(G1[1]), 64)) + int_to_hex(int(neg(G2)[0].coeffs[0]), 64) + int_to_hex(
             int(neg(G2)[0].coeffs[1]), 64) + int_to_hex(int(neg(G2)[1].coeffs[0]), 64) + int_to_hex(int(neg(G2)[1].coeffs[1]), 64),
         "ExpectedError": "g1 point is not on correct subgroup",
-        "Name": "bls_pairing_g1_not_in_correct_subgroup"
+        "Name": "bls_pairing_e(G1_not_in_correct_subgroup,-G2)=e(-G1,G2)"
         },
         {
         "Input": int_to_hex(int(G1[0]), 64) + (int_to_hex(int(G1[1]), 64)) + int_to_hex(int(G2_wrong_order[0].coeffs[0]), 64) + int_to_hex(
@@ -1488,7 +1632,7 @@ def case18_fail_pairing_check():
             int(G1[0]), 64) + (int_to_hex(int(G1[1]), 64)) + int_to_hex(int(neg(G2)[0].coeffs[0]), 64) + int_to_hex(
             int(neg(G2)[0].coeffs[1]), 64) + int_to_hex(int(neg(G2)[1].coeffs[0]), 64) + int_to_hex(int(neg(G2)[1].coeffs[1]), 64),
         "ExpectedError": "g2 point is not on correct subgroup",
-        "Name": "bls_pairing_g2_not_in_correct_subgroup"
+        "Name": "bls_pairing_e(G1,-G2_not_in_correct_subgroup)=e(-G1,G2)"
         }
     ]
 

--- a/main.py
+++ b/main.py
@@ -1495,7 +1495,7 @@ def case18_fail_pairing_check():
         {
         "Input": ""
             # G1 point (invalid field element)
-            + int_to_hex(int(G1[0]) + q, 64) # Plus Q
+            + int_to_hex(int(G1[0]) + q, 64)  # Plus Q
             + int_to_hex(int(G1[1]), 64)
             # G2 point (point at infinity)
             + int_to_hex(0, 256),
@@ -1507,7 +1507,7 @@ def case18_fail_pairing_check():
             # G1 point (point at infinity)
             + int_to_hex(0, 128)
             # G2 point (invalid field element)
-            + int_to_hex(int(G2[0].coeffs[0]) + q, 64) # Plus Q
+            + int_to_hex(int(G2[0].coeffs[0]) + q, 64)  # Plus Q
             + int_to_hex(int(G2[0].coeffs[1]), 64)
             + int_to_hex(int(G2[1].coeffs[0]), 64)
             + int_to_hex(int(G2[1].coeffs[1]), 64),
@@ -1517,7 +1517,7 @@ def case18_fail_pairing_check():
         {
         "Input": ""
             # G1 point
-            + int_to_hex(int(G1[0]) + q, 64) # Plus Q
+            + int_to_hex(int(G1[0]) + q, 64)  # Plus Q
             + int_to_hex(int(G1[1]), 64)
             # G2 point (invalid field element)
             + int_to_hex(int(G2[0].coeffs[0]), 64)
@@ -1533,7 +1533,7 @@ def case18_fail_pairing_check():
             + int_to_hex(int(G1[0]), 64)
             + int_to_hex(int(G1[1]), 64)
             # G2 point (invalid field element)
-            + int_to_hex(int(G2[0].coeffs[0]) + q, 64) # Plus Q
+            + int_to_hex(int(G2[0].coeffs[0]) + q, 64)  # Plus Q
             + int_to_hex(int(G2[0].coeffs[1]), 64)
             + int_to_hex(int(G2[1].coeffs[0]), 64)
             + int_to_hex(int(G2[1].coeffs[1]), 64),
@@ -1554,7 +1554,7 @@ def case18_fail_pairing_check():
             + int_to_hex(int(G1[0]), 64)
             + int_to_hex(int(G1[1]), 64)
             # G1 point 1
-            + int_to_hex(int(G2[0].coeffs[0]) + q, 64) # Plus Q
+            + int_to_hex(int(G2[0].coeffs[0]) + q, 64)  # Plus Q
             + int_to_hex(int(G2[0].coeffs[1]), 64)
             + int_to_hex(int(G2[1].coeffs[0]), 64)
             + int_to_hex(int(G2[1].coeffs[1]), 64)
@@ -1572,7 +1572,7 @@ def case18_fail_pairing_check():
         {
         "Input": ""
             # G1 point (not on curve)
-            + int_to_hex(int(P1[0]), 64) # Using P1 instead of G1
+            + int_to_hex(int(P1[0]), 64)  # Using P1 instead of G1
             + int_to_hex(int(G1[1]), 64)
             # G2 point (point at infinity)
             + int_to_hex(0, 256),
@@ -1584,7 +1584,7 @@ def case18_fail_pairing_check():
             # G1 point (point at infinity)
             + int_to_hex(0, 128)
             # G2 point (not on curve)
-            + int_to_hex(int(P2[0].coeffs[0]), 64) # Using P2 instead of G2
+            + int_to_hex(int(P2[0].coeffs[0]), 64)  # Using P2 instead of G2
             + int_to_hex(int(G2[0].coeffs[1]), 64)
             + int_to_hex(int(G2[1].coeffs[0]), 64)
             + int_to_hex(int(G2[1].coeffs[1]), 64),
@@ -1594,7 +1594,7 @@ def case18_fail_pairing_check():
         {
         "Input": ""
             # G1 point (not on curve)
-            + int_to_hex(int(P1[0]), 64) # Using P1 instead of G1
+            + int_to_hex(int(P1[0]), 64)  # Using P1 instead of G1
             + int_to_hex(int(G1[1]), 64)
             # G2 point
             + int_to_hex(int(G2[0].coeffs[0]), 64)
@@ -1610,7 +1610,7 @@ def case18_fail_pairing_check():
             + int_to_hex(int(G1[0]), 64)
             + int_to_hex(int(G1[1]), 64)
             # G2 point (not on curve)
-            + int_to_hex(int(P2[0].coeffs[0]), 64) # Using P2 instead of G2
+            + int_to_hex(int(P2[0].coeffs[0]), 64)  # Using P2 instead of G2
             + int_to_hex(int(G2[0].coeffs[1]), 64)
             + int_to_hex(int(G2[1].coeffs[0]), 64)
             + int_to_hex(int(G2[1].coeffs[1]), 64),

--- a/main.py
+++ b/main.py
@@ -1053,6 +1053,48 @@ def case09_pairing_check():
         "NoBenchmark": False
         },
         {
+        "Input": ""
+            # G1 point 1 (point at infinity)
+            + int_to_hex(0, 128)
+            # G2 point 1
+            + int_to_hex(int(G2[0].coeffs[0]), 64)
+            + int_to_hex(int(G2[0].coeffs[1]), 64)
+            + int_to_hex(int(G2[1].coeffs[0]), 64)
+            + int_to_hex(int(G2[1].coeffs[1]), 64)
+            # G1 point 2
+            + int_to_hex(int(G1[0]), 64)
+            + int_to_hex(int(G1[1]), 64)
+            # G2 point 2
+            + int_to_hex(int(neg(G2)[0].coeffs[0]), 64)
+            + int_to_hex(int(neg(G2)[0].coeffs[1]), 64)
+            + int_to_hex(int(neg(G2)[1].coeffs[0]), 64)
+            + int_to_hex(int(neg(G2)[1].coeffs[1]), 64),
+        "Name": "bls_pairing_e(0,-G2)!=e(-G1,G2)",
+        "Expected": int_to_hex(0, 32),
+        "Gas": 2 * BLS12_PAIRING_VARIABLE + BLS12_PAIRING_CONSTANT,
+        "NoBenchmark": False
+        },
+        {
+        "Input": ""
+            # G1 point 1
+            + int_to_hex(int(G1[0]), 64)
+            + int_to_hex(int(G1[1]), 64)
+            # G2 point 1 (point at infinity)
+            + int_to_hex(0, 256)
+            # G1 point 2
+            + int_to_hex(int(G1[0]), 64)
+            + int_to_hex(int(G1[1]), 64)
+            # G2 point 2
+            + int_to_hex(int(neg(G2)[0].coeffs[0]), 64)
+            + int_to_hex(int(neg(G2)[0].coeffs[1]), 64)
+            + int_to_hex(int(neg(G2)[1].coeffs[0]), 64)
+            + int_to_hex(int(neg(G2)[1].coeffs[1]), 64),
+        "Name": "bls_pairing_e(G1,0)!=e(-G1,G2)",
+        "Expected": int_to_hex(0, 32),
+        "Gas": 2 * BLS12_PAIRING_VARIABLE + BLS12_PAIRING_CONSTANT,
+        "NoBenchmark": False
+        },
+        {
         "Input": int_to_hex(int(G1[0]), 64) + (int_to_hex(int(G1[1]), 64)) + int_to_hex(0, 256) + int_to_hex(0, 128) + int_to_hex(int(G2[0].coeffs[0]), 64) + int_to_hex(
             int(G2[0].coeffs[1]), 64) + int_to_hex(int(G2[1].coeffs[0]), 64) + int_to_hex(int(G2[1].coeffs[1]), 64),
         "Name": "bls_pairing_e(G1,0)=e(0,G2)",


### PR DESCRIPTION
This PR adds a few new tests for the pairing check precompile.

#### Success cases

* `bls_pairing_e(0,G2)`
* `bls_pairing_e(G1,0)`
* `bls_pairing_e(0,-G2)!=e(-G1,G2)`
* `bls_pairing_e(G1,0)!=e(-G1,G2)`

#### Failure cases

##### Invalid field elements

* `bls_pairing_e(G1_invalid_field_element,0)`
* `bls_pairing_e(0,G2_invalid_field_element)`
* `bls_pairing_e(G1_invalid_field_element,G2)`
* `bls_pairing_e(G1,G2_invalid_field_element)`
* `bls_pairing_e(G1_invalid_field_element,-G2)=e(-G1,G2)` (renamed)
* `bls_pairing_e(G1,G2_invalid_field_element)=e(-G1,G2)` (new)

##### Not on curve

* `bls_pairing_e(G1_not_on_curve,0)`
* `bls_pairing_e(0,G2_not_on_curve)`
* `bls_pairing_e(G1_not_on_curve,G2)`
* `bls_pairing_e(G1,G2_not_on_curve)`
* `bls_pairing_e(G1_not_on_curve,-G2)=e(-G1,G2)` (renamed)
* `bls_pairing_e(G1,G2_not_on_curve)=e(-G1,G2)` (renamed)

##### Not in correct subgroup

* `bls_pairing_e(G1_not_in_correct_subgroup,0)`
* `bls_pairing_e(0,G2_not_in_correct_subgroup)`
* `bls_pairing_e(G1_not_in_correct_subgroup,G2)`
* `bls_pairing_e(G1,G2_not_in_correct_subgroup)`
* `bls_pairing_e(G1_not_in_correct_subgroup,-G2)=e(-G1,G2)` (renamed)
* `bls_pairing_e(G1,G2_not_in_correct_subgroup)=e(-G1,G2)` (renamed)