### PR TITLE
chore: Add static point at infinity test case

### DIFF
--- a/main.py
+++ b/main.py
@@ -1134,11 +1134,11 @@ def case07_msm_G1():
             + int_to_hex(int(G1[1]), 64)
             # scalar
             + int_to_hex(int(2), 32)
-            # G1 point
-            + int_to_hex(int(G1[0]), 64)
-            + int_to_hex(int(G1[1]), 64)
-            # zero
-            + int_to_hex(int(0), 32),
+            # point at infinity
+            + int_to_hex(0, 64)
+            + int_to_hex(0, 64)
+            # scalar
+            + int_to_hex(int(2), 32),
         "Name": "bls_g1msm_(2g1+inf)",
         "Expected": int_to_hex(int(result_doubling_G1[0]), 64) + (int_to_hex(int(result_doubling_G1[1]), 64)),
         "Gas": int((2 * BLS12_G1MUL_GAS * BLS12_G1_MULTIEXP_DISCOUNT_TABLE[1][1]) / 1000),


### PR DESCRIPTION
This brings the g1 version of 2g1+inf inline with the g2 version.

It is testing the case where we want to do a size 2 multiexp aG + bH , where H is the point at infinity versus bH being the point at infinity because b=0.

This edge case is important because many clients have code that filters out the point at infinity due to some libraries not handling them gracefully in an MSM.